### PR TITLE
Update dependencies

### DIFF
--- a/templates/Aardvark.Template.Rendering.FSharp/OpenGL/Aardvark.Template.Rendering.OpenGL.fsproj
+++ b/templates/Aardvark.Template.Rendering.FSharp/OpenGL/Aardvark.Template.Rendering.OpenGL.fsproj
@@ -21,8 +21,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aardvark.Application.Slim.GL" Version="4.10.3" />
-    <PackageReference Include="Aardvark.SceneGraph" Version="4.10.3" />
+    <PackageReference Include="Aardvark.Application.Slim.GL" Version="4.11.7" />
+    <PackageReference Include="Aardvark.SceneGraph" Version="4.11.7" />
   </ItemGroup>
 
 </Project>

--- a/templates/Aardvark.Template.Rendering.FSharp/Vulkan/Aardvark.Template.Rendering.Vulkan.fsproj
+++ b/templates/Aardvark.Template.Rendering.FSharp/Vulkan/Aardvark.Template.Rendering.Vulkan.fsproj
@@ -21,8 +21,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aardvark.Application.Slim.Vulkan" Version="4.10.3" />
-    <PackageReference Include="Aardvark.SceneGraph" Version="4.10.3" />
+    <PackageReference Include="Aardvark.Application.Slim.Vulkan" Version="4.11.7" />
+    <PackageReference Include="Aardvark.SceneGraph" Version="4.11.7" />
   </ItemGroup>
 
 </Project>

--- a/templates/Aardvark.Template.UI.FSharp/OpenGL/Aardvark.Template.UI.OpenGL.fsproj
+++ b/templates/Aardvark.Template.UI.FSharp/OpenGL/Aardvark.Template.UI.OpenGL.fsproj
@@ -23,11 +23,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aardvark.Application.Slim.GL" Version="4.10.3" />
-    <PackageReference Include="Aardvark.SceneGraph" Version="4.10.3" />
-    <PackageReference Include="Aardvark.UI" Version="4.5.14" />
-    <PackageReference Include="Aardvark.UI.Primitives" Version="4.5.14" />
-    <PackageReference Include="Suave" Version="2.2.1" />
+    <PackageReference Include="SourceLink.Embed.PaketFiles" Version="2.1.1" />
+    <PackageReference Include="Aardvark.Application.Slim.GL" Version="4.11.0" />
+    <PackageReference Include="Aardvark.UI" Version="4.6.0" />
+    <PackageReference Include="Aardvark.UI.Primitives" Version="4.6.0" />
     <PackageReference Include="Aardium" Version="1.0.21" />
   </ItemGroup>
 

--- a/templates/Aardvark.Template.UI.FSharp/Vulkan/Aardvark.Template.UI.Vulkan.fsproj
+++ b/templates/Aardvark.Template.UI.FSharp/Vulkan/Aardvark.Template.UI.Vulkan.fsproj
@@ -23,11 +23,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aardvark.Application.Slim.Vulkan" Version="4.10.3" />
-    <PackageReference Include="Aardvark.SceneGraph" Version="4.10.3" />
-    <PackageReference Include="Aardvark.UI" Version="4.5.14" />
-    <PackageReference Include="Aardvark.UI.Primitives" Version="4.5.14" />
-    <PackageReference Include="Suave" Version="2.2.1" />
+    <PackageReference Include="SourceLink.Embed.PaketFiles" Version="2.1.1" />
+    <PackageReference Include="Aardvark.Application.Slim.Vulkan" Version="4.11.0" />
+    <PackageReference Include="Aardvark.UI" Version="4.6.0" />
+    <PackageReference Include="Aardvark.UI.Primitives" Version="4.6.0" />
     <PackageReference Include="Aardium" Version="1.0.21" />
   </ItemGroup>
 


### PR DESCRIPTION
- Update dependencies to latest (`4.11.7`) in `Aardvark.Rendering` templates
- Update dependencies to `4.11.0` for `Aardvark.UI` template to avoid `NU1603` warnings

_Unresolved questions:_

The minimal version of rendering packages that `Aardvark.UI` works with is `4.10.0`. To make `Aardvark.UI` template work with latest (`4.11.7`) rendering dependencies according [this](https://github.com/NuGet/Home/issues/5764#issuecomment-323613059) we need to explicitly install higher versions of packages in dependency graph. For now stopper is `Aardvark.UI` package depends both on `Aardvark.Rendering.GL` and `Aardvark.Rendering.Vulkan`, so we need to specify, e.g. Vulkan package in the OpenGL project and vice versa.