### PR TITLE
Fix NU1608 warning

### DIFF
--- a/templates/Aardvark.Template.Rendering.FSharp/OpenGL/Aardvark.Template.Rendering.OpenGL.fsproj
+++ b/templates/Aardvark.Template.Rendering.FSharp/OpenGL/Aardvark.Template.Rendering.OpenGL.fsproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.0</TargetFramework>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -21,10 +20,11 @@
   </ItemGroup>
 
   <ItemGroup>
-  	<PackageReference Include="FSharp.Core" Version="4.6.2" />
-    <PackageReference Include="Aardvark.Application.Slim.GL" Version="4.12.3" />
+    <PackageReference Include="Aardvark.Application.Slim.Vulkan" Version="4.12.3" />
     <PackageReference Include="Aardvark.SceneGraph" Version="4.12.3" />
-    <PackageReference Include="Aardvark.Base" Version="4.5.22" />
+
+    <PackageReference Update="FSharp.Core" Version="4.6.2" />
+    <PackageReference Update="Aardvark.Base" Version="4.5.22" />
   </ItemGroup>
 
 </Project>

--- a/templates/Aardvark.Template.Rendering.FSharp/Vulkan/Aardvark.Template.Rendering.Vulkan.fsproj
+++ b/templates/Aardvark.Template.Rendering.FSharp/Vulkan/Aardvark.Template.Rendering.Vulkan.fsproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.0</TargetFramework>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -23,7 +22,9 @@
   <ItemGroup>
     <PackageReference Include="Aardvark.Application.Slim.Vulkan" Version="4.12.3" />
     <PackageReference Include="Aardvark.SceneGraph" Version="4.12.3" />
-    <PackageReference Include="Aardvark.Base" Version="4.5.22" />
+
+    <PackageReference Update="FSharp.Core" Version="4.6.2" />
+    <PackageReference Update="Aardvark.Base" Version="4.5.22" />
   </ItemGroup>
 
 </Project>

--- a/templates/Aardvark.Template.UI.FSharp/OpenGL/Aardvark.Template.UI.OpenGL.fsproj
+++ b/templates/Aardvark.Template.UI.FSharp/OpenGL/Aardvark.Template.UI.OpenGL.fsproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.0</TargetFramework>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -24,11 +23,18 @@
 
   <ItemGroup>
     <PackageReference Include="SourceLink.Embed.PaketFiles" Version="2.1.1" />
-    <PackageReference Include="Aardvark.Application.Slim.GL" Version="4.12.3" />
+
     <PackageReference Include="Aardvark.UI" Version="4.6.3" />
     <PackageReference Include="Aardvark.UI.Primitives" Version="4.6.3" />
     <PackageReference Include="Aardium" Version="1.0.21" />
-    <PackageReference Include="Aardvark.Base" Version="4.5.22" />
+
+    <PackageReference Include="Aardvark.Application.Slim.GL" Version="4.12.3" />
+    <PackageReference Include="Aardvark.Application.Slim.Vulkan" Version="4.12.3" />
+    <PackageReference Include="Aardvark.SceneGraph" Version="4.12.3" />
+    <PackageReference Include="Aardvark.GPGPU" Version="4.12.3" />
+
+    <PackageReference Update="FSharp.Core" Version="4.6.2" />
+    <PackageReference Update="Aardvark.Base" Version="4.5.22" />
   </ItemGroup>
 
 </Project>

--- a/templates/Aardvark.Template.UI.FSharp/Vulkan/Aardvark.Template.UI.Vulkan.fsproj
+++ b/templates/Aardvark.Template.UI.FSharp/Vulkan/Aardvark.Template.UI.Vulkan.fsproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.0</TargetFramework>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -24,11 +23,18 @@
 
   <ItemGroup>
     <PackageReference Include="SourceLink.Embed.PaketFiles" Version="2.1.1" />
-    <PackageReference Include="Aardvark.Application.Slim.Vulkan" Version="4.12.3" />
+
     <PackageReference Include="Aardvark.UI" Version="4.6.3" />
     <PackageReference Include="Aardvark.UI.Primitives" Version="4.6.3" />
     <PackageReference Include="Aardium" Version="1.0.21" />
-    <PackageReference Include="Aardvark.Base" Version="4.5.22" />
+
+    <PackageReference Include="Aardvark.Application.Slim.GL" Version="4.12.3" />
+    <PackageReference Include="Aardvark.Application.Slim.Vulkan" Version="4.12.3" />
+    <PackageReference Include="Aardvark.SceneGraph" Version="4.12.3" />
+    <PackageReference Include="Aardvark.GPGPU" Version="4.12.3" />
+
+    <PackageReference Update="FSharp.Core" Version="4.6.2" />
+    <PackageReference Update="Aardvark.Base" Version="4.5.22" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Resolve all warnings in three steps:

- lock FSharp.Core version to 4.6.2
- lock versions of all Aardvark related packages
- disable `AutoGenerateBindingRedirects` for fix weird Newtonsoft.Json versions mismatch (might need further investigations)