### PR TITLE
Update templates to Aardvark v5

### DIFF
--- a/Aardvark.Templates.csproj
+++ b/Aardvark.Templates.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageType>Template</PackageType>
-    <PackageVersion>1.1</PackageVersion>
+    <PackageVersion>1.2</PackageVersion>
     <PackageId>Aardvark.Templates</PackageId>
     <Title>Aardvark Platform Templates</Title>
     <Authors>Aardvark Platform Team</Authors>

--- a/templates/Aardvark.Template.Rendering.FSharp/OpenGL/Aardvark.Template.Rendering.OpenGL.fsproj
+++ b/templates/Aardvark.Template.Rendering.FSharp/OpenGL/Aardvark.Template.Rendering.OpenGL.fsproj
@@ -1,18 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>bin\Debug\</OutputPath>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>bin\Release\</OutputPath>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <RunWorkingDirectory>$(OutputPath)\$(TargetFramework)</RunWorkingDirectory>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -20,11 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aardvark.Application.Slim.GL" Version="4.12.3" />
-    <PackageReference Include="Aardvark.SceneGraph" Version="4.12.3" />
-
-    <PackageReference Update="FSharp.Core" Version="4.6.2" />
-    <PackageReference Update="Aardvark.Base" Version="4.5.22" />
+    <PackageReference Include="Aardvark.Application.Slim.GL" Version="5.0.7" />
+    <PackageReference Include="Aardvark.SceneGraph" Version="5.0.7" />
   </ItemGroup>
-
 </Project>

--- a/templates/Aardvark.Template.Rendering.FSharp/OpenGL/Program.fs
+++ b/templates/Aardvark.Template.Rendering.FSharp/OpenGL/Program.fs
@@ -1,17 +1,16 @@
 ﻿open System
 open Aardvark.Base
-open Aardvark.Base.Incremental
 open Aardvark.Base.Rendering
 open Aardvark.SceneGraph
 open Aardvark.Application
 open Aardvark.Application.Slim
+open FSharp.Data.Adaptive
 
 [<EntryPoint;STAThread>]
 let main argv = 
-    Ag.initialize()
     Aardvark.Init()
 
-    use app = new OpenGlApplication(true)
+    use app = new OpenGlApplication()
     use win = app.CreateGameWindow(8)
 
     let quadGeometry =
@@ -28,7 +27,7 @@ let main argv =
 
     let initialView = CameraView.lookAt (V3d(6,6,6)) V3d.Zero V3d.OOI
     let view = initialView |> DefaultCameraController.control win.Mouse win.Keyboard win.Time
-    let proj = win.Sizes |> Mod.map (fun s -> Frustum.perspective 60.0 0.1 100.0 (float s.X / float s.Y))
+    let proj = win.Sizes |> AVal.map (fun s -> Frustum.perspective 60.0 0.1 100.0 (float s.X / float s.Y))
 
 
     let sg =
@@ -38,8 +37,8 @@ let main argv =
                 DefaultSurfaces.trafo |> toEffect
                 DefaultSurfaces.vertexColor |> toEffect
                ]
-            |> Sg.viewTrafo (view |> Mod.map CameraView.viewTrafo)
-            |> Sg.projTrafo (proj |> Mod.map Frustum.projTrafo)
+            |> Sg.viewTrafo (view |> AVal.map CameraView.viewTrafo)
+            |> Sg.projTrafo (proj |> AVal.map Frustum.projTrafo)
 
     
     let task =

--- a/templates/Aardvark.Template.Rendering.FSharp/Vulkan/Aardvark.Template.Rendering.Vulkan.fsproj
+++ b/templates/Aardvark.Template.Rendering.FSharp/Vulkan/Aardvark.Template.Rendering.Vulkan.fsproj
@@ -1,18 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>bin\Debug\</OutputPath>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>bin\Release\</OutputPath>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <RunWorkingDirectory>$(OutputPath)\$(TargetFramework)</RunWorkingDirectory>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -20,11 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aardvark.Application.Slim.Vulkan" Version="4.12.3" />
-    <PackageReference Include="Aardvark.SceneGraph" Version="4.12.3" />
-
-    <PackageReference Update="FSharp.Core" Version="4.6.2" />
-    <PackageReference Update="Aardvark.Base" Version="4.5.22" />
+    <PackageReference Include="Aardvark.Application.Slim.Vulkan" Version="5.0.7" />
+    <PackageReference Include="Aardvark.SceneGraph" Version="5.0.7" />
   </ItemGroup>
-
 </Project>

--- a/templates/Aardvark.Template.Rendering.FSharp/Vulkan/Program.fs
+++ b/templates/Aardvark.Template.Rendering.FSharp/Vulkan/Program.fs
@@ -1,17 +1,16 @@
 ﻿open System
 open Aardvark.Base
-open Aardvark.Base.Incremental
 open Aardvark.Base.Rendering
 open Aardvark.SceneGraph
 open Aardvark.Application
 open Aardvark.Application.Slim
+open FSharp.Data.Adaptive
 
 [<EntryPoint;STAThread>]
 let main argv = 
-    Ag.initialize()
     Aardvark.Init()
 
-    use app = new VulkanApplication(true)
+    use app = new VulkanApplication()
     use win = app.CreateGameWindow(8)
 
     let quadGeometry =
@@ -28,7 +27,7 @@ let main argv =
 
     let initialView = CameraView.lookAt (V3d(6,6,6)) V3d.Zero V3d.OOI
     let view = initialView |> DefaultCameraController.control win.Mouse win.Keyboard win.Time
-    let proj = win.Sizes |> Mod.map (fun s -> Frustum.perspective 60.0 0.1 100.0 (float s.X / float s.Y))
+    let proj = win.Sizes |> AVal.map (fun s -> Frustum.perspective 60.0 0.1 100.0 (float s.X / float s.Y))
 
 
     let sg =
@@ -38,8 +37,8 @@ let main argv =
                 DefaultSurfaces.trafo |> toEffect
                 DefaultSurfaces.vertexColor |> toEffect
                ]
-            |> Sg.viewTrafo (view |> Mod.map CameraView.viewTrafo)
-            |> Sg.projTrafo (proj |> Mod.map Frustum.projTrafo)
+            |> Sg.viewTrafo (view |> AVal.map CameraView.viewTrafo)
+            |> Sg.projTrafo (proj |> AVal.map Frustum.projTrafo)
 
     
     let task =

--- a/templates/Aardvark.Template.UI.FSharp/OpenGL/Aardvark.Template.UI.OpenGL.fsproj
+++ b/templates/Aardvark.Template.UI.FSharp/OpenGL/Aardvark.Template.UI.OpenGL.fsproj
@@ -1,18 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>bin\Debug\</OutputPath>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>bin\Release\</OutputPath>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <RunWorkingDirectory>$(OutputPath)\$(TargetFramework)</RunWorkingDirectory>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -22,19 +11,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SourceLink.Embed.PaketFiles" Version="2.1.1" />
+    <PackageReference Include="Aardvark.UI" Version="5.0.4" />
+    <PackageReference Include="Aardvark.UI.Primitives" Version="5.0.4" />
+    <PackageReference Include="Aardium" Version="1.1.0" />
+    <PackageReference Include="Adaptify.MSBuild" Version="1.0.0" />
 
-    <PackageReference Include="Aardvark.UI" Version="4.6.3" />
-    <PackageReference Include="Aardvark.UI.Primitives" Version="4.6.3" />
-    <PackageReference Include="Aardium" Version="1.0.21" />
+    <PackageReference Include="Aardvark.Application.Slim.GL" Version="5.0.7" />
+    <PackageReference Include="Aardvark.Application.Slim.Vulkan" Version="5.0.7" />
+    <PackageReference Include="Aardvark.SceneGraph" Version="5.0.7" />
+    <PackageReference Include="Aardvark.GPGPU" Version="5.0.7" />
 
-    <PackageReference Include="Aardvark.Application.Slim.GL" Version="4.12.3" />
-    <PackageReference Include="Aardvark.Application.Slim.Vulkan" Version="4.12.3" />
-    <PackageReference Include="Aardvark.SceneGraph" Version="4.12.3" />
-    <PackageReference Include="Aardvark.GPGPU" Version="4.12.3" />
-
-    <PackageReference Update="FSharp.Core" Version="4.6.2" />
-    <PackageReference Update="Aardvark.Base" Version="4.5.22" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
-
 </Project>

--- a/templates/Aardvark.Template.UI.FSharp/OpenGL/App.fs
+++ b/templates/Aardvark.Template.UI.FSharp/OpenGL/App.fs
@@ -1,11 +1,11 @@
 ﻿namespace Aardvark.Template.UI
 
-open System
 open Aardvark.Base
-open Aardvark.Base.Incremental
+open Aardvark.Base.Rendering
 open Aardvark.UI
 open Aardvark.UI.Primitives
-open Aardvark.Base.Rendering
+open FSharp.Data.Adaptive
+
 open Aardvark.Template.UI.Model
 
 type Message =
@@ -26,17 +26,17 @@ module App =
             | CameraMessage msg ->
                 { m with cameraState = FreeFlyController.update m.cameraState msg }
 
-    let view (m : MModel) =
+    let view (m : AdaptiveModel) =
 
         let frustum = 
             Frustum.perspective 60.0 0.1 100.0 1.0 
-                |> Mod.constant
+                |> AVal.constant
 
         let sg =
-            m.currentModel |> Mod.map (fun v ->
+            m.currentModel |> AVal.map (fun v ->
                 match v with
-                    | Box -> Sg.box (Mod.constant C4b.Red) (Mod.constant (Box3d(-V3d.III, V3d.III)))
-                    | Sphere -> Sg.sphere 5 (Mod.constant C4b.Green) (Mod.constant 1.0)
+                    | Box -> Sg.box (AVal.constant C4b.Red) (AVal.constant (Box3d(-V3d.III, V3d.III)))
+                    | Sphere -> Sg.sphere 5 (AVal.constant C4b.Green) (AVal.constant 1.0)
             )
             |> Sg.dynamic
             |> Sg.shader {
@@ -63,6 +63,6 @@ module App =
             initial = initial
             update = update
             view = view
-            threads = Model.Lens.cameraState.Get >> FreeFlyController.threads >> ThreadPool.map CameraMessage
+            threads = fun m -> m.cameraState |> FreeFlyController.threads |> ThreadPool.map CameraMessage
             unpersist = Unpersist.instance
         }

--- a/templates/Aardvark.Template.UI.FSharp/OpenGL/Model.fs
+++ b/templates/Aardvark.Template.UI.FSharp/OpenGL/Model.fs
@@ -1,16 +1,14 @@
 ﻿namespace Aardvark.Template.UI.Model
 
-open System
-open Aardvark.Base
-open Aardvark.Base.Incremental
 open Aardvark.UI.Primitives
+open Adaptify
 
 type Primitive =
     | Box
     | Sphere
 
 
-[<DomainType>]
+[<ModelType>]
 type Model =
     {
         currentModel    : Primitive

--- a/templates/Aardvark.Template.UI.FSharp/OpenGL/Program.fs
+++ b/templates/Aardvark.Template.UI.FSharp/OpenGL/Program.fs
@@ -1,19 +1,13 @@
 ﻿open Aardvark.Template.UI
 
-open Aardium
-open Aardvark.Service
-open Aardvark.UI
-open Suave
-open Suave.WebPart
-open Aardvark.Rendering.GL
-open Aardvark.Application
-open Aardvark.Application.Slim
 open Aardvark.Base
-open System
+open Aardvark.UI
+open Aardvark.Application.Slim
+open Aardium
+open Suave
 
 [<EntryPoint>]
 let main args =
-    Ag.initialize()
     Aardvark.Init()
     Aardium.init()
 

--- a/templates/Aardvark.Template.UI.FSharp/Vulkan/Aardvark.Template.UI.Vulkan.fsproj
+++ b/templates/Aardvark.Template.UI.FSharp/Vulkan/Aardvark.Template.UI.Vulkan.fsproj
@@ -1,18 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>bin\Debug\</OutputPath>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>bin\Release\</OutputPath>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <RunWorkingDirectory>$(OutputPath)\$(TargetFramework)</RunWorkingDirectory>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -22,19 +11,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SourceLink.Embed.PaketFiles" Version="2.1.1" />
+    <PackageReference Include="Aardvark.UI" Version="5.0.4" />
+    <PackageReference Include="Aardvark.UI.Primitives" Version="5.0.4" />
+    <PackageReference Include="Aardium" Version="1.1.0" />
+    <PackageReference Include="Adaptify.MSBuild" Version="1.0.0" />
 
-    <PackageReference Include="Aardvark.UI" Version="4.6.3" />
-    <PackageReference Include="Aardvark.UI.Primitives" Version="4.6.3" />
-    <PackageReference Include="Aardium" Version="1.0.21" />
+    <PackageReference Include="Aardvark.Application.Slim.GL" Version="5.0.7" />
+    <PackageReference Include="Aardvark.Application.Slim.Vulkan" Version="5.0.7" />
+    <PackageReference Include="Aardvark.SceneGraph" Version="5.0.7" />
+    <PackageReference Include="Aardvark.GPGPU" Version="5.0.7" />
 
-    <PackageReference Include="Aardvark.Application.Slim.GL" Version="4.12.3" />
-    <PackageReference Include="Aardvark.Application.Slim.Vulkan" Version="4.12.3" />
-    <PackageReference Include="Aardvark.SceneGraph" Version="4.12.3" />
-    <PackageReference Include="Aardvark.GPGPU" Version="4.12.3" />
-
-    <PackageReference Update="FSharp.Core" Version="4.6.2" />
-    <PackageReference Update="Aardvark.Base" Version="4.5.22" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
-
 </Project>

--- a/templates/Aardvark.Template.UI.FSharp/Vulkan/App.fs
+++ b/templates/Aardvark.Template.UI.FSharp/Vulkan/App.fs
@@ -1,11 +1,11 @@
 ﻿namespace Aardvark.Template.UI
 
-open System
 open Aardvark.Base
-open Aardvark.Base.Incremental
+open Aardvark.Base.Rendering
 open Aardvark.UI
 open Aardvark.UI.Primitives
-open Aardvark.Base.Rendering
+open FSharp.Data.Adaptive
+
 open Aardvark.Template.UI.Model
 
 type Message =
@@ -26,17 +26,17 @@ module App =
             | CameraMessage msg ->
                 { m with cameraState = FreeFlyController.update m.cameraState msg }
 
-    let view (m : MModel) =
+    let view (m : AdaptiveModel) =
 
         let frustum = 
             Frustum.perspective 60.0 0.1 100.0 1.0 
-                |> Mod.constant
+                |> AVal.constant
 
         let sg =
-            m.currentModel |> Mod.map (fun v ->
+            m.currentModel |> AVal.map (fun v ->
                 match v with
-                    | Box -> Sg.box (Mod.constant C4b.Red) (Mod.constant (Box3d(-V3d.III, V3d.III)))
-                    | Sphere -> Sg.sphere 5 (Mod.constant C4b.Green) (Mod.constant 1.0)
+                    | Box -> Sg.box (AVal.constant C4b.Red) (AVal.constant (Box3d(-V3d.III, V3d.III)))
+                    | Sphere -> Sg.sphere 5 (AVal.constant C4b.Green) (AVal.constant 1.0)
             )
             |> Sg.dynamic
             |> Sg.shader {
@@ -63,6 +63,6 @@ module App =
             initial = initial
             update = update
             view = view
-            threads = Model.Lens.cameraState.Get >> FreeFlyController.threads >> ThreadPool.map CameraMessage
+            threads = fun m -> m.cameraState |> FreeFlyController.threads |> ThreadPool.map CameraMessage
             unpersist = Unpersist.instance
         }

--- a/templates/Aardvark.Template.UI.FSharp/Vulkan/Model.fs
+++ b/templates/Aardvark.Template.UI.FSharp/Vulkan/Model.fs
@@ -1,16 +1,14 @@
 ﻿namespace Aardvark.Template.UI.Model
 
-open System
-open Aardvark.Base
-open Aardvark.Base.Incremental
 open Aardvark.UI.Primitives
+open Adaptify
 
 type Primitive =
     | Box
     | Sphere
 
 
-[<DomainType>]
+[<ModelType>]
 type Model =
     {
         currentModel    : Primitive

--- a/templates/Aardvark.Template.UI.FSharp/Vulkan/Program.fs
+++ b/templates/Aardvark.Template.UI.FSharp/Vulkan/Program.fs
@@ -1,21 +1,17 @@
 ﻿open Aardvark.Template.UI
 
-open Aardium
-open Aardvark.Service
-open Aardvark.UI
-open Suave
-open Suave.WebPart
-open Aardvark.Rendering.Vulkan
 open Aardvark.Base
-open System
+open Aardvark.UI
+open Aardvark.Application.Slim
+open Aardium
+open Suave
 
 [<EntryPoint>]
 let main args =
-    Ag.initialize()
     Aardvark.Init()
     Aardium.init()
 
-    let app = new HeadlessVulkanApplication()
+    let app = new VulkanApplication()
 
     WebPart.startServer 4321 [
         MutableApp.toWebPart' app.Runtime false (App.start App.app)


### PR DESCRIPTION
Project files for Aardvark v5 look cleaner, but still have some weird explicit dependencies:

- on `FSharp.Data.Adaptive`; should disappear  after https://github.com/fsprojects/FSharp.Data.Adaptive/issues/71 resolved;
- on `SourceLink.Embed.PaketFiles`; shoud disappear after https://github.com/aardvark-platform/aardvark.base/issues/47 and https://github.com/aardvark-platform/aardvark.media/issues/32 resolved.

I have also experimented a little with Paket as dotnet tool and Paket-based templates. It works fine but need more work on projects structure (introduce solution + F# project + Paket files) and also complicated build process a bit (first need to restore tool, then install deps and so on). So I decided to not go this way for now.

cc @haraldsteinlechner @krauthaufen What do you think?